### PR TITLE
Prepare ETHRegistrar for 3-letter (and longer) names

### DIFF
--- a/contracts/ETHRegistrarController.sol
+++ b/contracts/ETHRegistrarController.sol
@@ -4,6 +4,7 @@ import "./PriceOracle.sol";
 import "./BaseRegistrar.sol";
 import "./StringUtils.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "@ensdomains/resolver/contracts/Resolver.sol";
 
 /**
  * @dev A registrar controller for registering and renewing names at fixed cost.
@@ -21,6 +22,9 @@ contract ETHRegistrarController is Ownable {
         keccak256("commit(bytes32)") ^
         keccak256("register(string,address,uint256,bytes32)") ^
         keccak256("renew(string,uint256)")
+    );
+    bytes4 constant private COMMITMENT_WITH_CONFIG_CONTROLLER_ID = bytes4(
+        keccak256("registerWithConfig(string,address,uint256,bytes32,address,address)")
     );
 
     BaseRegistrar base;
@@ -48,7 +52,7 @@ contract ETHRegistrarController is Ownable {
         return prices.price(name, base.nameExpires(uint256(hash)), duration);
     }
 
-    function valid(string memory name) public view returns(bool) {
+    function valid(string memory name) public pure returns(bool) {
         return name.strlen() >= 3;
     }
 
@@ -62,14 +66,18 @@ contract ETHRegistrarController is Ownable {
         return keccak256(abi.encodePacked(label, owner, secret));
     }
 
+    function makeCommitmentWithConfig(string memory name, address owner, bytes32 secret, address resolver, address addr) pure public returns(bytes32) {
+        bytes32 label = keccak256(bytes(name));
+        return keccak256(abi.encodePacked(label, owner, secret, resolver, addr));
+    }
+
     function commit(bytes32 commitment) public {
         require(commitments[commitment] + maxCommitmentAge < now);
         commitments[commitment] = now;
     }
 
-    function register(string calldata name, address owner, uint duration, bytes32 secret) external payable {
+    function _invalidateCommitment(string memory name, uint duration, bytes32 commitment) internal returns (uint256) {
         // Require a valid commitment
-        bytes32 commitment = makeCommitment(name, owner, secret);
         require(commitments[commitment] + minCommitmentAge <= now);
 
         // If the commitment is too old, or the name is registered, stop
@@ -82,10 +90,48 @@ contract ETHRegistrarController is Ownable {
         require(duration >= MIN_REGISTRATION_DURATION);
         require(msg.value >= cost);
 
+        return cost;
+    }
+
+    function register(string calldata name, address owner, uint duration, bytes32 secret) external payable {
+        bytes32 commitment = makeCommitment(name, owner, secret);
+        uint cost = _invalidateCommitment(name, duration, commitment);
+
         bytes32 label = keccak256(bytes(name));
         uint expires = base.register(uint256(label), owner, duration);
         emit NameRegistered(name, label, owner, cost, expires);
 
+        if(msg.value > cost) {
+            msg.sender.transfer(msg.value - cost);
+        }
+    }
+
+    function registerWithConfig(string calldata name, address owner, uint duration, bytes32 secret, address resolver, address addr) external payable {
+        bytes32 commitment = makeCommitmentWithConfig(name, owner, secret, resolver, addr);
+        uint cost = _invalidateCommitment(name, duration, commitment);
+
+        bytes32 label = keccak256(bytes(name));
+        uint256 tokenId = uint256(label);
+
+        // Set this contract as the (temporary) owner, giving it
+        // permission to set up the resolver.
+        uint expires = base.register(tokenId, address(this), duration);
+
+        // The nodehash of this label
+        bytes32 nodehash = keccak256(abi.encodePacked(base.baseNode(), label));
+
+        // Set the resolver
+        base.ens().setResolver(nodehash, resolver);
+
+        // Configure the resolver
+        Resolver(resolver).setAddr(nodehash, addr);
+
+        // Now transfer full ownership to the expeceted owner
+        base.transferFrom(address(this), owner, tokenId);
+
+        emit NameRegistered(name, label, owner, cost, expires);
+
+        // Refund any extra payment
         if(msg.value > cost) {
             msg.sender.transfer(msg.value - cost);
         }
@@ -121,6 +167,7 @@ contract ETHRegistrarController is Ownable {
 
     function supportsInterface(bytes4 interfaceID) external pure returns (bool) {
         return interfaceID == INTERFACE_META_ID ||
-               interfaceID == COMMITMENT_CONTROLLER_ID;
+               interfaceID == COMMITMENT_CONTROLLER_ID ||
+               interfaceID == COMMITMENT_WITH_CONFIG_CONTROLLER_ID;
     }
 }

--- a/contracts/ETHRegistrarController.sol
+++ b/contracts/ETHRegistrarController.sol
@@ -49,7 +49,7 @@ contract ETHRegistrarController is Ownable {
     }
 
     function valid(string memory name) public view returns(bool) {
-        return name.strlen() > 6;
+        return name.strlen() >= 3;
     }
 
     function available(string memory name) public view returns(bool) {

--- a/contracts/ETHRegistrarController.sol
+++ b/contracts/ETHRegistrarController.sol
@@ -80,23 +80,6 @@ contract ETHRegistrarController is Ownable {
         commitments[commitment] = now;
     }
 
-    function _consumeCommitment(string memory name, uint duration, bytes32 commitment) internal returns (uint256) {
-        // Require a valid commitment
-        require(commitments[commitment] + minCommitmentAge <= now);
-
-        // If the commitment is too old, or the name is registered, stop
-        require(commitments[commitment] + maxCommitmentAge > now);
-        require(available(name));
-
-        delete(commitments[commitment]);
-
-        uint cost = rentPrice(name, duration);
-        require(duration >= MIN_REGISTRATION_DURATION);
-        require(msg.value >= cost);
-
-        return cost;
-    }
-
     function register(string calldata name, address owner, uint duration, bytes32 secret) external payable {
         bytes32 commitment = makeCommitmentWithConfig(name, owner, secret, address(0), address(0));
         uint cost = _consumeCommitment(name, duration, commitment);
@@ -175,5 +158,22 @@ contract ETHRegistrarController is Ownable {
         return interfaceID == INTERFACE_META_ID ||
                interfaceID == COMMITMENT_CONTROLLER_ID ||
                interfaceID == COMMITMENT_WITH_CONFIG_CONTROLLER_ID;
+    }
+
+    function _consumeCommitment(string memory name, uint duration, bytes32 commitment) internal returns (uint256) {
+        // Require a valid commitment
+        require(commitments[commitment] + minCommitmentAge <= now);
+
+        // If the commitment is too old, or the name is registered, stop
+        require(commitments[commitment] + maxCommitmentAge > now);
+        require(available(name));
+
+        delete(commitments[commitment]);
+
+        uint cost = rentPrice(name, duration);
+        require(duration >= MIN_REGISTRATION_DURATION);
+        require(msg.value >= cost);
+
+        return cost;
     }
 }

--- a/contracts/ETHRegistrarController.sol
+++ b/contracts/ETHRegistrarController.sol
@@ -72,7 +72,7 @@ contract ETHRegistrarController is Ownable {
         if (resolver == address(0) && addr == address(0)) {
             return keccak256(abi.encodePacked(label, owner, secret));
         }
-        return keccak256(abi.encodePacked(label, owner, secret, resolver, addr));
+        return keccak256(abi.encodePacked(label, owner, resolver, addr, secret));
     }
 
     function commit(bytes32 commitment) public {

--- a/contracts/ETHRegistrarController.sol
+++ b/contracts/ETHRegistrarController.sol
@@ -72,6 +72,7 @@ contract ETHRegistrarController is Ownable {
         if (resolver == address(0) && addr == address(0)) {
             return keccak256(abi.encodePacked(label, owner, secret));
         }
+        require(resolver != address(0));
         return keccak256(abi.encodePacked(label, owner, resolver, addr, secret));
     }
 

--- a/contracts/ETHRegistrarController.sol
+++ b/contracts/ETHRegistrarController.sol
@@ -23,8 +23,10 @@ contract ETHRegistrarController is Ownable {
         keccak256("register(string,address,uint256,bytes32)") ^
         keccak256("renew(string,uint256)")
     );
+
     bytes4 constant private COMMITMENT_WITH_CONFIG_CONTROLLER_ID = bytes4(
-        keccak256("registerWithConfig(string,address,uint256,bytes32,address,address)")
+        keccak256("registerWithConfig(string,address,uint256,bytes32,address,address)") ^
+        keccak256("makeCommitmentWithConfig(string,address,bytes32,address,address)")
     );
 
     BaseRegistrar base;
@@ -62,12 +64,14 @@ contract ETHRegistrarController is Ownable {
     }
 
     function makeCommitment(string memory name, address owner, bytes32 secret) pure public returns(bytes32) {
-        bytes32 label = keccak256(bytes(name));
-        return keccak256(abi.encodePacked(label, owner, secret));
+        return makeCommitmentWithConfig(name, owner, secret, address(0), address(0));
     }
 
     function makeCommitmentWithConfig(string memory name, address owner, bytes32 secret, address resolver, address addr) pure public returns(bytes32) {
         bytes32 label = keccak256(bytes(name));
+        if (resolver == address(0) && addr == address(0)) {
+            return keccak256(abi.encodePacked(label, owner, secret));
+        }
         return keccak256(abi.encodePacked(label, owner, secret, resolver, addr));
     }
 

--- a/contracts/_TestDeps2.sol
+++ b/contracts/_TestDeps2.sol
@@ -1,0 +1,2 @@
+import "@ensdomains/resolver/contracts/PublicResolver.sol";
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,9 +107,9 @@
       }
     },
     "@ensdomains/resolver": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@ensdomains/resolver/-/resolver-0.1.10.tgz",
-      "integrity": "sha512-r+zkzH/sx0PyFhvC+3jAW53kvBsYqzeVJ4xcaEKNi5F/xX5BnGLshSn5z+9lMkiS+tFf1Ucs7/V039W1KZWmaw=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@ensdomains/resolver/-/resolver-0.1.13.tgz",
+      "integrity": "sha512-VcMygGO/b0H4AXkN4CRAHw0CZd5XvTJW8YdIdZEmpJGs/O3eMzBzxpgJJ7UerD7U098rbBDSJmj0zjGudV0/aQ=="
     },
     "@types/bn.js": {
       "version": "4.11.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,11 @@
         }
       }
     },
+    "@ensdomains/resolver": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@ensdomains/resolver/-/resolver-0.1.10.tgz",
+      "integrity": "sha512-r+zkzH/sx0PyFhvC+3jAW53kvBsYqzeVJ4xcaEKNi5F/xX5BnGLshSn5z+9lMkiS+tFf1Ucs7/V039W1KZWmaw=="
+    },
     "@types/bn.js": {
       "version": "4.11.4",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.4.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@ensdomains/dnsregistrar": "^0.3.5",
     "@ensdomains/dnssec-oracle": "^0.1.2",
     "@ensdomains/ens": "^0.3.6",
-    "@ensdomains/resolver": "^0.1.10",
+    "@ensdomains/resolver": "^0.1.13",
     "bluebird": "^3.5.3",
     "eth-ens-namehash": "^2.0.8",
     "openzeppelin-solidity": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@ensdomains/dnsregistrar": "^0.3.5",
     "@ensdomains/dnssec-oracle": "^0.1.2",
     "@ensdomains/ens": "^0.3.6",
+    "@ensdomains/resolver": "^0.1.10",
     "bluebird": "^3.5.3",
     "eth-ens-namehash": "^2.0.8",
     "openzeppelin-solidity": "2.1.3",

--- a/test/test_eth_registrar_controller.js
+++ b/test/test_eth_registrar_controller.js
@@ -83,6 +83,36 @@ contract('ETHRegistrarController', function (accounts) {
 			await baseRegistrar.addController(controller.address, {from: ownerAccount});
 		});
 
+		const checkLabels = {
+		    "testing": true,
+		    "longname12345678": true,
+		    "sixsix": true,
+		    "five5": true,
+		    "four": true,
+		    "iii": true,
+		    "ii": false,
+		    "i": false,
+		    "": false,
+
+		    // { ni } { hao } { ma } (chinese; simplified)
+		    "\u4f60\u597d\u5417": true,
+
+		    // { ta } { ko } (japanese; hiragana)
+		    "\u305f\u3053": false,
+
+		    // { poop } { poop } { poop } (emoji)
+		    "\ud83d\udca9\ud83d\udca9\ud83d\udca9": true,
+
+		    // { poop } { poop } (emoji)
+		    "\ud83d\udca9\ud83d\udca9": false
+		};
+
+		it('should report label validity', async () => {
+		    for (const label in checkLabels) {
+		        assert.equal(await controller.valid(label), checkLabels[label], label);
+		    }
+		});
+
 		it('should report unused names as available', async () => {
 			assert.equal(await controller.available(sha3('available')), true);
 		});


### PR DESCRIPTION
Prepare the ETHRegistrar for 3-letter (and longer) names.

Also adds the ability for a one-shot configuration, setting up a resolver and resolved address at commitment time for the registration call.

-----

**Note:**

The test cases require [this line in resolvers](https://github.com/ensdomains/resolvers/blob/master/contracts/profiles/AddrResolver.sol#L1) to be changed to `^0.5.0`.

Updating the version of `solc` in *ethregistrar* breaks the test suite (seems there is a breaking change in the solc output that truffle depends on?), so pulling the *resolvers* package in breaks things because that file indicates it needs a version of the compiler newer than *ethregistrar* is able to use.

For a quick fix, you can update the value in the `node_modules/`, but ideally truffle needs to support 0.5.8 (or someone who better understands truffle can figure out what I couldn't :)) or less-ideally, change the AddrProfile pragma to `^0.5.0`.