### PR TITLE
Reclaim before transfer

### DIFF
--- a/contracts/ETHRegistrarController.sol
+++ b/contracts/ETHRegistrarController.sol
@@ -110,6 +110,7 @@ contract ETHRegistrarController is Ownable {
             }
 
             // Now transfer full ownership to the expeceted owner
+            base.reclaim(tokenId, owner);
             base.transferFrom(address(this), owner, tokenId);
         } else {
             require(addr == address(0));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/ethregistrar",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "",
   "main": "truffle-config.js",
   "directories": {

--- a/test/test_eth_registrar_controller.js
+++ b/test/test_eth_registrar_controller.js
@@ -157,6 +157,7 @@ contract('ETHRegistrarController', function (accounts) {
 
 			var nodehash = namehash.hash("newconfigname.eth");
 			assert.equal((await ens.resolver(nodehash)), resolver.address);
+			assert.equal((await ens.owner(nodehash)), registrantAccount);
 			assert.equal((await resolver.addr(nodehash)), registrantAccount);
 		});
 


### PR DESCRIPTION
The current implementation leaves the controller (aka the owner of the registry, deed owner) to the contract address of `ETHRegistrarController` (NOTE: these two are super confusing. We definitely need to change the controller on the UI to admin or operator or something else besides "controller") and prevents from the user from changing addresses or any other fields until they set it to themselves.

<img width="956" alt="Screenshot 2019-11-06 at 14 12 57" src="https://user-images.githubusercontent.com/2630/68307312-ee3e8c80-00a2-11ea-8bf5-8d4d6f8e59a2.png">

The fix will claim it to the user so that the user can start setting records immediately after the registration.

<img width="616" alt="Screenshot 2019-11-06 at 14 40 27" src="https://user-images.githubusercontent.com/2630/68307576-67d67a80-00a3-11ea-9711-95199e332e5d.png">

Good job on @jefflau for catching this error on the integration test of `ens-app`!

cc @ricmoo 